### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: SPEC-6 CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/1minhtaocompany/lush-givex-worker/security/code-scanning/5](https://github.com/1minhtaocompany/lush-givex-worker/security/code-scanning/5)

General fix: define explicit `permissions` for the workflow or for the `ci_checks` job so that the `GITHUB_TOKEN` follows the principle of least privilege. For this workflow, `contents: read` is sufficient for checking out code and running dependency review, and no write permissions are required.

Best concrete fix: add a top-level `permissions` block after the `name` (or after `on:`) that applies to all jobs without their own `permissions`. Set it to `contents: read`. No other permissions appear necessary from the shown steps. The change is confined to `.github/workflows/ci.yml`, adding just a few lines and not altering any existing behavior.

Specifically:
- In `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top-level of the workflow (e.g., between `name: SPEC-6 CI` and `on:`).  
- No additional methods, imports, or definitions are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
