### PR TITLE
Reconstruct start/stop race condition tests with all PR #131 review improvements

### DIFF
--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -387,6 +387,60 @@ class TestStartStopRace(RuntimeResetMixin, unittest.TestCase):
         self.assertLessEqual(results.count(True), 1)
         self.assertFalse(is_running())
 
+    def test_no_duplicate_loop_thread_during_stopping(self):
+        """_loop_thread must not be replaced while state is STOPPING."""
+        started = start(lambda _: time.sleep(0.5), interval=0.05)
+        self.assertTrue(started)
+        time.sleep(0.1)
+        with runtime._lock:
+            runtime._state = "STOPPING"
+            self.assertIsNotNone(runtime._loop_thread)
+            original_thread = runtime._loop_thread
+        # Attempt start while STOPPING — must be rejected
+        self.assertFalse(start(lambda _: None, interval=0.05))
+        with runtime._lock:
+            self.assertIs(runtime._loop_thread, original_thread)
+            runtime._state = "RUNNING"
+        stop(timeout=2)
+
+    def test_concurrent_start_stop_deterministic(self):
+        """Racing start() vs stop() — if both succeed, runtime must not remain RUNNING."""
+        for _ in range(10):
+            start_result = [None]
+            stop_result = [None]
+            barrier = threading.Barrier(2)
+
+            def do_start():
+                barrier.wait()
+                start_result[0] = start(lambda _: time.sleep(0.5), interval=0.05)
+
+            def do_stop():
+                barrier.wait()
+                stop_result[0] = stop(timeout=2)
+
+            t1 = threading.Thread(target=do_start)
+            t2 = threading.Thread(target=do_stop)
+            t1.start()
+            t2.start()
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+            # Assert threads actually completed (not timed-out)
+            self.assertFalse(t1.is_alive(), "start thread did not finish")
+            self.assertFalse(t2.is_alive(), "stop thread did not finish")
+            # Assert results are booleans, not None (threads ran their targets)
+            self.assertIsInstance(start_result[0], bool)
+            self.assertIsInstance(stop_result[0], bool)
+            # Mutual exclusion: if both start() and stop() claim success,
+            # the runtime must NOT be left in RUNNING — that would mean
+            # stop() reported success while the lifecycle is still active.
+            if start_result[0] and stop_result[0]:
+                self.assertNotEqual(get_state(), "RUNNING")
+            # Clean up for next iteration
+            if is_running():
+                stop(timeout=2)
+            if get_state() != "INIT":
+                reset()
+
 
 class TestWorkerRegistryConsistency(RuntimeResetMixin, unittest.TestCase):
     """Worker registry must stay consistent under concurrent operations."""


### PR DESCRIPTION
Reconstructs the concurrency tests from #131 with all review improvements applied, replacing the original revert.

## Changes Made

- **`test_no_duplicate_loop_thread_during_stopping`**: Restored with fixes for vacuous assertions — asserts `start()` returned `True` and `_loop_thread is not None` before capturing the reference, then validates thread identity is preserved during STOPPING state.
- **`test_concurrent_start_stop_deterministic`**: Restored with deterministic barriers, thread completion validation (`not t.is_alive()` after joins), result type assertions (`isinstance(result, bool)`), and corrected docstring to match actual assertion semantics.

## Improvements over original #131

- No vacuous assertions — initial `start()` success and `_loop_thread` presence are explicitly validated
- Real thread execution verified — threads are checked for completion after `join()` with timeout
- Results validated as booleans, not `None`, ensuring thread targets actually executed
- Docstring accurately reflects assertion: "if both succeed, runtime must not remain RUNNING"
- Deterministic timing via `threading.Barrier`

No runtime logic was modified. All 214 tests pass.